### PR TITLE
Add missing opcodes

### DIFF
--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -425,10 +425,26 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			vm.regs[inst.Dst] &= uint64(inst.Constant)
 		case asm.And.Op(asm.RegSource):
 			vm.regs[inst.Dst] &= vm.regs[inst.Src]
+		case asm.And.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) & uint32(inst.Constant))
+		case asm.And.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) & uint32(vm.regs[inst.Src]))
 		case asm.Or.Op(asm.ImmSource):
 			vm.regs[inst.Dst] |= uint64(inst.Constant)
 		case asm.Or.Op(asm.RegSource):
 			vm.regs[inst.Dst] |= vm.regs[inst.Src]
+		case asm.Or.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) | uint32(inst.Constant))
+		case asm.Or.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) | uint32(vm.regs[inst.Src]))
+		case asm.Xor.Op(asm.ImmSource):
+			vm.regs[inst.Dst] ^= uint64(inst.Constant)
+		case asm.Xor.Op(asm.RegSource):
+			vm.regs[inst.Dst] ^= vm.regs[inst.Src]
+		case asm.Xor.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) ^ uint32(inst.Constant))
+		case asm.Xor.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) ^ uint32(vm.regs[inst.Src]))
 
 		//
 		case asm.JEq.Op(asm.ImmSource):

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -348,8 +348,20 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 		//
 		case asm.LSh.Op(asm.ImmSource):
 			vm.regs[inst.Dst] <<= uint64(inst.Constant)
+		case asm.LSh.Op(asm.RegSource):
+			vm.regs[inst.Dst] <<= uint64(vm.regs[inst.Src])
+		case asm.LSh.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) << uint32(inst.Constant))
+		case asm.LSh.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) << uint32(vm.regs[inst.Src]))
 		case asm.RSh.Op(asm.ImmSource):
 			vm.regs[inst.Dst] >>= uint64(inst.Constant)
+		case asm.RSh.Op(asm.RegSource):
+			vm.regs[inst.Dst] >>= uint64(vm.regs[inst.Src])
+		case asm.RSh.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
+		case asm.RSh.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
 
 		//
 		case asm.StoreMemOp(asm.DWord):

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -367,9 +367,9 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 		case asm.ArSh.Op(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(int64(vm.regs[inst.Dst]) >> uint64(vm.regs[inst.Src]))
 		case asm.ArSh.Op32(asm.ImmSource):
-			vm.regs[inst.Dst] = uint64(int32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
+			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
 		case asm.ArSh.Op32(asm.RegSource):
-			vm.regs[inst.Dst] = uint64(int32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
+			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
 
 		//
 		case asm.StoreMemOp(asm.DWord):
@@ -401,12 +401,14 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			}
 
 		//
-		case asm.Mov.Op(asm.RegSource):
-			vm.regs[inst.Dst] = vm.regs[inst.Src]
 		case asm.Mov.Op(asm.ImmSource):
 			vm.regs[inst.Dst] = uint64(inst.Constant)
+		case asm.Mov.Op(asm.RegSource):
+			vm.regs[inst.Dst] = vm.regs[inst.Src]
 		case asm.Mov.Op32(asm.ImmSource):
-			vm.regs[inst.Dst] = uint64(inst.Constant)
+			vm.regs[inst.Dst] = signExtend(int32(inst.Constant))
+		case asm.Mov.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Src]))
 
 		//
 		case asm.Add.Op(asm.ImmSource):
@@ -553,4 +555,8 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 	}
 
 	return ErrorCode, errors.New("unexpected error")
+}
+
+func signExtend(in int32) uint64 {
+	return uint64(int64(in))
 }

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -367,9 +367,9 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 		case asm.ArSh.Op(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(int64(vm.regs[inst.Dst]) >> uint64(vm.regs[inst.Src]))
 		case asm.ArSh.Op32(asm.ImmSource):
-			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
+			vm.regs[inst.Dst] = zeroExtend(int32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
 		case asm.ArSh.Op32(asm.RegSource):
-			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
+			vm.regs[inst.Dst] = zeroExtend(int32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
 
 		//
 		case asm.StoreMemOp(asm.DWord):
@@ -406,9 +406,9 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 		case asm.Mov.Op(asm.RegSource):
 			vm.regs[inst.Dst] = vm.regs[inst.Src]
 		case asm.Mov.Op32(asm.ImmSource):
-			vm.regs[inst.Dst] = signExtend(int32(inst.Constant))
+			vm.regs[inst.Dst] = zeroExtend(int32(inst.Constant))
 		case asm.Mov.Op32(asm.RegSource):
-			vm.regs[inst.Dst] = signExtend(int32(vm.regs[inst.Src]))
+			vm.regs[inst.Dst] = zeroExtend(int32(vm.regs[inst.Src]))
 
 		//
 		case asm.Add.Op(asm.ImmSource):
@@ -557,6 +557,6 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 	return ErrorCode, errors.New("unexpected error")
 }
 
-func signExtend(in int32) uint64 {
-	return uint64(int64(in))
+func zeroExtend(in int32) uint64 {
+	return uint64(uint32(in))
 }

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -362,6 +362,14 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
 		case asm.RSh.Op32(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
+		case asm.ArSh.Op(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(int64(vm.regs[inst.Dst]) >> uint64(inst.Constant))
+		case asm.ArSh.Op(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(int64(vm.regs[inst.Dst]) >> uint64(vm.regs[inst.Src]))
+		case asm.ArSh.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(int32(vm.regs[inst.Dst]) >> uint32(inst.Constant))
+		case asm.ArSh.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(int32(vm.regs[inst.Dst]) >> uint32(vm.regs[inst.Src]))
 
 		//
 		case asm.StoreMemOp(asm.DWord):

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -489,18 +489,28 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if vm.regs[inst.Dst] == uint64(inst.Constant) {
 				pc += int(inst.Offset)
 			}
+		case asm.JEq.Op(asm.RegSource):
+			if vm.regs[inst.Dst] == vm.regs[inst.Src] {
+				pc += int(inst.Offset)
+			}
+		case asm.OpCode(asm.Jump32Class).SetJumpOp(asm.JEq).SetSource(asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) == uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case asm.OpCode(asm.Jump32Class).SetJumpOp(asm.JEq).SetSource(asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) == uint32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.Ja.Op(asm.ImmSource):
 			pc += int(inst.Offset)
+		case asm.Ja.Op(asm.RegSource):
+			pc += int(vm.regs[inst.Src])
 		case asm.JNE.Op(asm.ImmSource):
 			if vm.regs[inst.Dst] != uint64(inst.Constant) {
 				pc += int(inst.Offset)
 			}
 		case asm.JNE.Op(asm.RegSource):
 			if vm.regs[inst.Dst] != vm.regs[inst.Src] {
-				pc += int(inst.Offset)
-			}
-		case asm.JEq.Op(asm.RegSource):
-			if vm.regs[inst.Dst] == vm.regs[inst.Src] {
 				pc += int(inst.Offset)
 			}
 		case asm.JGE.Op(asm.RegSource):

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -493,11 +493,11 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if vm.regs[inst.Dst] == vm.regs[inst.Src] {
 				pc += int(inst.Offset)
 			}
-		case asm.OpCode(asm.Jump32Class).SetJumpOp(asm.JEq).SetSource(asm.ImmSource):
+		case JumpOpCode(asm.Jump32Class, asm.JEq, asm.ImmSource):
 			if uint32(vm.regs[inst.Dst]) == uint32(inst.Constant) {
 				pc += int(inst.Offset)
 			}
-		case asm.OpCode(asm.Jump32Class).SetJumpOp(asm.JEq).SetSource(asm.RegSource):
+		case JumpOpCode(asm.Jump32Class, asm.JEq, asm.RegSource):
 			if uint32(vm.regs[inst.Dst]) == uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
@@ -513,12 +513,28 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if vm.regs[inst.Dst] != vm.regs[inst.Src] {
 				pc += int(inst.Offset)
 			}
+		case JumpOpCode(asm.Jump32Class, asm.JNE, asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) != uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JNE, asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) != uint32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JGE.Op(asm.RegSource):
 			if vm.regs[inst.Dst] >= vm.regs[inst.Src] {
 				pc += int(inst.Offset)
 			}
 		case asm.JGE.Op(asm.ImmSource):
 			if vm.regs[inst.Dst] >= uint64(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JGE, asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) >= uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JGE, asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) >= uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
 		case asm.JGT.Op(asm.RegSource):
@@ -529,6 +545,14 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if vm.regs[inst.Dst] > uint64(inst.Constant) {
 				pc += int(inst.Offset)
 			}
+		case JumpOpCode(asm.Jump32Class, asm.JGT, asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) > uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JGT, asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) > uint32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JLE.Op(asm.RegSource):
 			if vm.regs[inst.Dst] <= vm.regs[inst.Src] {
 				pc += int(inst.Offset)
@@ -537,12 +561,28 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if vm.regs[inst.Dst] <= uint64(inst.Constant) {
 				pc += int(inst.Offset)
 			}
+		case JumpOpCode(asm.Jump32Class, asm.JLE, asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) <= uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JLE, asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) <= uint32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JLT.Op(asm.RegSource):
 			if vm.regs[inst.Dst] < vm.regs[inst.Src] {
 				pc += int(inst.Offset)
 			}
 		case asm.JLT.Op(asm.ImmSource):
 			if vm.regs[inst.Dst] < uint64(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JLT, asm.ImmSource):
+			if uint32(vm.regs[inst.Dst]) < uint32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JLT, asm.RegSource):
+			if uint32(vm.regs[inst.Dst]) < uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
 
@@ -569,4 +609,8 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 
 func zeroExtend(in int32) uint64 {
 	return uint64(uint32(in))
+}
+
+func JumpOpCode(class asm.Class, jumpOp asm.JumpOp, source asm.Source) asm.OpCode {
+	return asm.OpCode(class).SetJumpOp(jumpOp).SetSource(source)
 }

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -426,13 +426,29 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 		case asm.Mul.Op32(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) * uint32(vm.regs[inst.Src]))
 		case asm.Div.Op(asm.ImmSource):
-			vm.regs[inst.Dst] /= uint64(inst.Constant)
+			if uint64(inst.Constant) == 0 {
+				vm.regs[inst.Dst] = 0
+			} else {
+				vm.regs[inst.Dst] /= uint64(inst.Constant)
+			}
 		case asm.Div.Op(asm.RegSource):
-			vm.regs[inst.Dst] /= vm.regs[inst.Src]
+			if uint64(vm.regs[inst.Src]) == 0 {
+				vm.regs[inst.Dst] = 0
+			} else {
+				vm.regs[inst.Dst] /= vm.regs[inst.Src]
+			}
 		case asm.Div.Op32(asm.ImmSource):
-			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(inst.Constant))
+			if uint32(inst.Constant) == 0 {
+				vm.regs[inst.Dst] = 0
+			} else {
+				vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(inst.Constant))
+			}
 		case asm.Div.Op32(asm.RegSource):
-			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(vm.regs[inst.Src]))
+			if uint32(vm.regs[inst.Src]) == 0 {
+				vm.regs[inst.Dst] = 0
+			} else {
+				vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(vm.regs[inst.Src]))
+			}
 		case asm.And.Op(asm.ImmSource):
 			vm.regs[inst.Dst] &= uint64(inst.Constant)
 		case asm.And.Op(asm.RegSource):

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -397,6 +397,30 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) + uint32(inst.Constant))
 		case asm.Add.Op32(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) + uint32(vm.regs[inst.Src]))
+		case asm.Sub.Op(asm.ImmSource):
+			vm.regs[inst.Dst] -= uint64(inst.Constant)
+		case asm.Sub.Op(asm.RegSource):
+			vm.regs[inst.Dst] -= vm.regs[inst.Src]
+		case asm.Sub.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) - uint32(inst.Constant))
+		case asm.Sub.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) - uint32(vm.regs[inst.Src]))
+		case asm.Mul.Op(asm.ImmSource):
+			vm.regs[inst.Dst] *= uint64(inst.Constant)
+		case asm.Mul.Op(asm.RegSource):
+			vm.regs[inst.Dst] *= vm.regs[inst.Src]
+		case asm.Mul.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) * uint32(inst.Constant))
+		case asm.Mul.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) * uint32(vm.regs[inst.Src]))
+		case asm.Div.Op(asm.ImmSource):
+			vm.regs[inst.Dst] /= uint64(inst.Constant)
+		case asm.Div.Op(asm.RegSource):
+			vm.regs[inst.Dst] /= vm.regs[inst.Src]
+		case asm.Div.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(inst.Constant))
+		case asm.Div.Op32(asm.RegSource):
+			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(vm.regs[inst.Src]))
 		case asm.And.Op(asm.ImmSource):
 			vm.regs[inst.Dst] &= uint64(inst.Constant)
 		case asm.And.Op(asm.RegSource):


### PR DESCRIPTION
Added in this PR:
- sub/mul/div
- and32/or32/xor
- arithmetic shift + missing lsh/rsh ops
- 32bit versions of jump opcodes

After this PR: conformance score = 64 / 128