### PR TITLE
missing opcodes - second round

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libboost-all-dev
+          sudo apt-get install -y libboost-program-options-dev libboost-filesystem-dev
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/conformance_tests/driver.go
+++ b/conformance_tests/driver.go
@@ -58,7 +58,7 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf("%x\n", code)
+	fmt.Printf("%x\n", uint64(code))
 }
 
 func decode_hexa(in string) ([]byte, error) {

--- a/conformance_tests/driver.go
+++ b/conformance_tests/driver.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -23,16 +22,19 @@ func main() {
 		panic(err)
 	}
 
-	memory := flag.Arg(0)
-
 	programByteCode, err := decode_hexa(string(program))
 	if err != nil {
 		panic(err)
 	}
 
-	_, err = decode_hexa(memory)
-	if err != nil {
-		panic(err)
+	var memoryBytes []byte
+	if len(os.Args) > 1 {
+		memory := os.Args[1]
+		mb, err := decode_hexa(memory)
+		if err != nil {
+			panic(err)
+		}
+		memoryBytes = mb
 	}
 
 	var instructions asm.Instructions
@@ -51,8 +53,7 @@ func main() {
 
 	vm := baloum.NewVM(spec, baloum.Opts{})
 
-	var ctx baloum.Context
-	code, err := vm.RunProgram(ctx, TEST_RUN_SECTION)
+	code, err := vm.RunProgramWithRawMemory(memoryBytes, TEST_RUN_SECTION)
 	if err != nil {
 		panic(err)
 	}

--- a/conformance_tests/driver.go
+++ b/conformance_tests/driver.go
@@ -53,7 +53,7 @@ func main() {
 
 	vm := baloum.NewVM(spec, baloum.Opts{})
 
-	code, err := vm.RunProgramWithRawMemory(memoryBytes, TEST_RUN_SECTION)
+	code, err := vm.RunProgramWithRawMemory(memoryBytes, TEST_RUN_SECTION, true)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -558,7 +558,7 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 				pc += int(inst.Offset)
 			}
 		case asm.JSGE.Op(asm.ImmSource):
-			if int64(vm.regs[inst.Dst]) >= int64(inst.Constant) {
+			if int64(vm.regs[inst.Dst]) >= inst.Constant {
 				pc += int(inst.Offset)
 			}
 		case JumpOpCode(asm.Jump32Class, asm.JSGE, asm.ImmSource):
@@ -585,6 +585,22 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if uint32(vm.regs[inst.Dst]) > uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
+		case asm.JSGT.Op(asm.RegSource):
+			if int64(vm.regs[inst.Dst]) > int64(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
+		case asm.JSGT.Op(asm.ImmSource):
+			if int64(vm.regs[inst.Dst]) > inst.Constant {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSGT, asm.ImmSource):
+			if int32(vm.regs[inst.Dst]) > int32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSGT, asm.RegSource):
+			if int32(vm.regs[inst.Dst]) > int32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JLE.Op(asm.RegSource):
 			if vm.regs[inst.Dst] <= vm.regs[inst.Src] {
 				pc += int(inst.Offset)
@@ -601,6 +617,22 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if uint32(vm.regs[inst.Dst]) <= uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
+		case asm.JSLE.Op(asm.RegSource):
+			if int64(vm.regs[inst.Dst]) <= int64(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
+		case asm.JSLE.Op(asm.ImmSource):
+			if int64(vm.regs[inst.Dst]) <= inst.Constant {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSLE, asm.ImmSource):
+			if int32(vm.regs[inst.Dst]) <= int32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSLE, asm.RegSource):
+			if int32(vm.regs[inst.Dst]) <= int32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JLT.Op(asm.RegSource):
 			if vm.regs[inst.Dst] < vm.regs[inst.Src] {
 				pc += int(inst.Offset)
@@ -615,6 +647,22 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			}
 		case JumpOpCode(asm.Jump32Class, asm.JLT, asm.RegSource):
 			if uint32(vm.regs[inst.Dst]) < uint32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
+		case asm.JSLT.Op(asm.RegSource):
+			if int64(vm.regs[inst.Dst]) < int64(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
+		case asm.JSLT.Op(asm.ImmSource):
+			if int64(vm.regs[inst.Dst]) < inst.Constant {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSLT, asm.ImmSource):
+			if int32(vm.regs[inst.Dst]) < int32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSLT, asm.RegSource):
+			if int32(vm.regs[inst.Dst]) < int32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
 

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -415,6 +415,27 @@ func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error)
 				return ErrorCode, err
 			}
 
+		case asm.StoreImmOp(asm.DWord):
+			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
+			if err := vm.setUint64(dstAddr, uint64(inst.Constant)); err != nil {
+				return ErrorCode, err
+			}
+		case asm.StoreImmOp(asm.Word):
+			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
+			if err := vm.setUint32(dstAddr, uint32(inst.Constant)); err != nil {
+				return ErrorCode, err
+			}
+		case asm.StoreImmOp(asm.Half):
+			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
+			if err := vm.setUint16(dstAddr, uint16(inst.Constant)); err != nil {
+				return ErrorCode, err
+			}
+		case asm.StoreImmOp(asm.Byte):
+			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
+			if err := vm.setUint8(dstAddr, uint8(inst.Constant)); err != nil {
+				return ErrorCode, err
+			}
+
 		//
 		case asm.StoreXAddOp(asm.DWord):
 			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -142,6 +142,15 @@ func (vm *VM) getUint16(addr uint64) (uint16, error) {
 	return ByteOrder.Uint16(bytes), nil
 }
 
+func (vm *VM) getUint8(addr uint64) (uint8, error) {
+	bytes, err := vm.getBytes(addr, 1)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint8(bytes[0]), nil
+}
+
 func (vm *VM) getString(addr uint64) (string, error) {
 	data, addr, err := vm.getMem(addr)
 	if err != nil {
@@ -325,6 +334,13 @@ func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error)
 		case asm.LoadMemOp(asm.Half):
 			srcAddr := vm.regs[inst.Src] + uint64(inst.Offset)
 			value, err := vm.getUint16(srcAddr)
+			if err != nil {
+				return ErrorCode, err
+			}
+			vm.regs[inst.Dst] = uint64(value)
+		case asm.LoadMemOp(asm.Byte):
+			srcAddr := vm.regs[inst.Src] + uint64(inst.Offset)
+			value, err := vm.getUint8(srcAddr)
 			if err != nil {
 				return ErrorCode, err
 			}

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -211,6 +211,14 @@ func (vm *VM) addUint64(addr uint64, inc uint64) error {
 	return vm.setUint64(addr, value+inc)
 }
 
+func (vm *VM) addUint32(addr uint64, inc uint32) error {
+	value, err := vm.getUint32(addr)
+	if err != nil {
+		return err
+	}
+	return vm.setUint32(addr, value+inc)
+}
+
 func isStrSection(name string) bool {
 	return strings.HasPrefix(name, "rodatastr") || strings.HasPrefix(name, ".rodata.str")
 }
@@ -440,6 +448,11 @@ func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error)
 		case asm.StoreXAddOp(asm.DWord):
 			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
 			if err := vm.addUint64(dstAddr, vm.regs[inst.Src]); err != nil {
+				return ErrorCode, err
+			}
+		case asm.StoreXAddOp(asm.Word):
+			dstAddr := vm.regs[inst.Dst] + uint64(inst.Offset)
+			if err := vm.addUint32(dstAddr, uint32(vm.regs[inst.Src])); err != nil {
 				return ErrorCode, err
 			}
 

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -267,6 +267,10 @@ func getNormalizedInsts(prog *ebpf.ProgramSpec) []asm.Instruction {
 }
 
 func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
+	return vm.RunProgramWithRawMemory(ctx.Bytes(), section)
+}
+
+func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error) {
 	var prog *ebpf.ProgramSpec
 	for _, p := range vm.Spec.Programs {
 		if progMatch(p, section) {
@@ -287,7 +291,7 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 	// new state
 	vm.stack = make([]byte, vm.Opts.StackSize)
 	vm.regs[asm.RFP] = uint64(len(vm.stack))
-	vm.regs[asm.R1] = vm.heap.AllocWith(ctx.Bytes())
+	vm.regs[asm.R1] = vm.heap.AllocWith(bytes)
 
 	if err := vm.maps.LoadMaps(vm.Spec, section); err != nil {
 		return ErrorCode, err

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -485,6 +485,10 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) ^ uint32(vm.regs[inst.Src]))
 
 		//
+		case asm.Ja.Op(asm.ImmSource):
+			pc += int(inst.Offset)
+		case asm.Ja.Op(asm.RegSource):
+			pc += int(vm.regs[inst.Src])
 		case asm.JEq.Op(asm.ImmSource):
 			if vm.regs[inst.Dst] == uint64(inst.Constant) {
 				pc += int(inst.Offset)
@@ -501,10 +505,22 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if uint32(vm.regs[inst.Dst]) == uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
-		case asm.Ja.Op(asm.ImmSource):
-			pc += int(inst.Offset)
-		case asm.Ja.Op(asm.RegSource):
-			pc += int(vm.regs[inst.Src])
+		case asm.JSet.Op(asm.ImmSource):
+			if (vm.regs[inst.Dst] & uint64(inst.Constant)) != 0 {
+				pc += int(inst.Offset)
+			}
+		case asm.JSet.Op(asm.RegSource):
+			if (vm.regs[inst.Dst] & vm.regs[inst.Src]) != 0 {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSet, asm.ImmSource):
+			if (uint32(vm.regs[inst.Dst]) & uint32(inst.Constant)) != 0 {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSet, asm.RegSource):
+			if (uint32(vm.regs[inst.Dst]) & uint32(vm.regs[inst.Src])) != 0 {
+				pc += int(inst.Offset)
+			}
 		case asm.JNE.Op(asm.ImmSource):
 			if vm.regs[inst.Dst] != uint64(inst.Constant) {
 				pc += int(inst.Offset)

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -553,6 +553,22 @@ func (vm *VM) RunProgram(ctx Context, section string) (int, error) {
 			if uint32(vm.regs[inst.Dst]) >= uint32(vm.regs[inst.Src]) {
 				pc += int(inst.Offset)
 			}
+		case asm.JSGE.Op(asm.RegSource):
+			if int64(vm.regs[inst.Dst]) >= int64(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
+		case asm.JSGE.Op(asm.ImmSource):
+			if int64(vm.regs[inst.Dst]) >= int64(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSGE, asm.ImmSource):
+			if int32(vm.regs[inst.Dst]) >= int32(inst.Constant) {
+				pc += int(inst.Offset)
+			}
+		case JumpOpCode(asm.Jump32Class, asm.JSGE, asm.RegSource):
+			if int32(vm.regs[inst.Dst]) >= int32(vm.regs[inst.Src]) {
+				pc += int(inst.Offset)
+			}
 		case asm.JGT.Op(asm.RegSource):
 			if vm.regs[inst.Dst] > vm.regs[inst.Src] {
 				pc += int(inst.Offset)

--- a/pkg/baloum/vm.go
+++ b/pkg/baloum/vm.go
@@ -504,6 +504,30 @@ func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error)
 			} else {
 				vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) / uint32(vm.regs[inst.Src]))
 			}
+		case asm.Mod.Op(asm.ImmSource):
+			if uint64(inst.Constant) == 0 {
+				vm.regs[inst.Dst] = 1
+			} else {
+				vm.regs[inst.Dst] %= uint64(inst.Constant)
+			}
+		case asm.Mod.Op(asm.RegSource):
+			if uint64(vm.regs[inst.Src]) == 0 {
+				vm.regs[inst.Dst] = 1
+			} else {
+				vm.regs[inst.Dst] %= vm.regs[inst.Src]
+			}
+		case asm.Mod.Op32(asm.ImmSource):
+			if uint32(inst.Constant) == 0 {
+				vm.regs[inst.Dst] = 1
+			} else {
+				vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) % uint32(inst.Constant))
+			}
+		case asm.Mod.Op32(asm.RegSource):
+			if uint32(vm.regs[inst.Src]) == 0 {
+				vm.regs[inst.Dst] = 1
+			} else {
+				vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) % uint32(vm.regs[inst.Src]))
+			}
 		case asm.And.Op(asm.ImmSource):
 			vm.regs[inst.Dst] &= uint64(inst.Constant)
 		case asm.And.Op(asm.RegSource):
@@ -528,6 +552,12 @@ func (vm *VM) RunProgramWithRawMemory(bytes []byte, section string) (int, error)
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) ^ uint32(inst.Constant))
 		case asm.Xor.Op32(asm.RegSource):
 			vm.regs[inst.Dst] = uint64(uint32(vm.regs[inst.Dst]) ^ uint32(vm.regs[inst.Src]))
+
+		//
+		case asm.Neg.Op(asm.ImmSource):
+			vm.regs[inst.Dst] = -vm.regs[inst.Src]
+		case asm.Neg.Op32(asm.ImmSource):
+			vm.regs[inst.Dst] = zeroExtend(-int32(vm.regs[inst.Src]))
 
 		//
 		case asm.Ja.Op(asm.ImmSource):


### PR DESCRIPTION
This PR adds:
- signed jumps
- raw memory setup function for tests
- faster CI (less boost installation)
- byte swap opcodes
- mod and neg
- atomic opcodes (cmpxchg included)

Conformance score: 128 / 128 -> 100%